### PR TITLE
Selecting the first proposal automatically on iPad

### DIFF
--- a/swift-evolution/sourcecode/controllers/proposals/list/ListProposalsViewController.swift
+++ b/swift-evolution/sourcecode/controllers/proposals/list/ListProposalsViewController.swift
@@ -17,8 +17,17 @@ class ListProposalsViewController: BaseViewController {
     }()
     
     fileprivate var dataSource: [Proposal] = {
-       return []
-    }()
+        return []
+        }() {
+        didSet {
+            guard
+                oldValue.isEmpty,
+                let proposal = dataSource.first,
+                UIDevice.current.userInterfaceIdiom == .pad
+                else { return }
+            DispatchQueue.main.async { self.didSelected(proposal: proposal) }
+        }
+    }
     
     fileprivate weak var appDelegate: AppDelegate?
     
@@ -417,7 +426,7 @@ extension ListProposalsViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerCell = tableView.cell(forClass: ProposalListHeaderTableViewCell.self)
-    
+
         headerCell.proposalCount = self.filteredDataSource.count
         
         return headerCell.contentView


### PR DESCRIPTION
When the proposals list loads on iPad, the details screen still shows `No Selected Proposal`. This commit selects the first proposal automatically on iPad after the proposals list is retrieved from the backend.

- [x] Project builds and runs as expected.
- [x] No new linting violations have been introduced.
- [x] No new bugs have been introduced.
- [x] I have reviewed the [contributing guide](https://github.com/swift-evolution/ios/blob/development/.github/CONTRIBUTING.md)
- [ ] I'm attaching to this PR some screenshots (if applicable)