### PR TITLE
Don’t show zero count while proposals are loading

### DIFF
--- a/swift-evolution/sourcecode/controllers/proposals/list/ListProposalsViewController.swift
+++ b/swift-evolution/sourcecode/controllers/proposals/list/ListProposalsViewController.swift
@@ -425,6 +425,10 @@ extension ListProposalsViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard !dataSource.isEmpty else {
+            return nil
+        }
+        
         let headerCell = tableView.cell(forClass: ProposalListHeaderTableViewCell.self)
 
         headerCell.proposalCount = self.filteredDataSource.count


### PR DESCRIPTION
## Changes in this pull request

* Only show the proposal count after loading has finished

# Before

![simulator screen shot - iphone 8 - 2018-01-17 at 16 12 34](https://user-images.githubusercontent.com/6910829/35067403-c43fe300-fba1-11e7-852e-70440500f6cc.png)

# After

![simulator screen shot - iphone 8 - 2018-01-17 at 16 12 16](https://user-images.githubusercontent.com/6910829/35067414-cd8477c8-fba1-11e7-8d40-8203c9be7dea.png)

### Checklist

- [x] Project builds and runs as expected.
- [x] No new linting violations have been introduced.
- [x] No new bugs have been introduced.
- [x] I have reviewed the [contributing guide](https://github.com/swift-evolution/ios/blob/development/.github/CONTRIBUTING.md)
- [x] I'm attaching to this PR some screenshots (if applicable)